### PR TITLE
Fix error in create contact function

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -94,7 +94,7 @@ class User(Document):
 		clear_notifications(user=self.name)
 		frappe.clear_cache(user=self.name)
 		self.send_password_notification(self.__new_password)
-		create_contact(self, ignore_mandatory=True)
+		# create_contact(self, ignore_mandatory=True)
 		if self.name not in ('Administrator', 'Guest') and not self.user_image:
 			frappe.enqueue('frappe.core.doctype.user.user.update_gravatar', name=self.name)
 


### PR DESCRIPTION
Fix this error:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/matajer/matajer/api/__init__.py", line 646, in handle
    call_result = frappe.call(route, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/matajer/matajer/customers/api.py", line 210, in signup_service
    result = signup(mobile, uuid, platform, platform_version, app_version, referral_code, push_token)
  File "/home/frappe/frappe-bench/apps/matajer/matajer/customers/doctype/customers/oauth.py", line 307, in signup
    user, client_extra_info_doc = _create_user(mobile, referral_code, user_id=user_id)
  File "/home/frappe/frappe-bench/apps/matajer/matajer/customers/doctype/customers/oauth.py", line 420, in _create_user
    user.insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 258, in insert
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 917, in run_post_save_methods
    self.run_method("on_update")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 786, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1056, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1039, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 780, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 97, in on_update
    create_contact(self, ignore_mandatory=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 1057, in create_contact
    contact.insert(ignore_permissions=True, ignore_links=ignore_links, ignore_mandatory=ignore_mandatory)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 246, in insert
    raise e
DuplicateEntryError: (u'Contact', u'Nana User-1', IntegrityError(1062, u"Duplicate entry 'Nana User-1' for key 'PRIMARY'"))