### PR TITLE
consider automation dir to be excluded from compile

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -235,7 +235,7 @@ def migrate(context, rebuild_website=False, skip_failing=False):
 			frappe.destroy()
 
 	print("Compiling Python Files...")
-	compileall.compile_dir('../apps', quiet=1, rx=re.compile('.*node_modules.*'))
+	compileall.compile_dir('../apps', quiet=1, rx=re.compile('.*node_modules.*|.*automation.*'))
 
 @click.command('run-patch')
 @click.argument('module')


### PR DESCRIPTION
automation will be added to frappe apps and may contains code written in other languages or versions and using different environments, to avoid compile these files and I have updated the regex to ignore this dir during compile process

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.